### PR TITLE
Add CUE files for panel plugins

### DIFF
--- a/BarChart/backend/bar.cue
+++ b/BarChart/backend/bar.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+kind: "BarChart"
+spec: close({
+	calculation: common.#calculation
+	format?:     common.#format
+	sort?:       "asc" | "desc"
+	mode?:       "value" | "percentage"
+})

--- a/BarChart/backend/bar.json
+++ b/BarChart/backend/bar.json
@@ -1,0 +1,12 @@
+{
+  "kind": "BarChart",
+  "spec": {
+    "calculation": "last-number",
+    "format": {
+      "unit": "percent",
+      "decimalPlaces": 2
+    },
+    "sort": "desc",
+    "mode": "value"
+  }
+}

--- a/BarChart/backend/migrate.cue
+++ b/BarChart/backend/migrate.cue
@@ -1,0 +1,23 @@
+ if #panel.type != _|_ if #panel.type == "bargauge" {
+	kind: "BarChart"
+	spec: {
+		#calcName:   *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's BarChart doesn't support individual calcs
+		calculation: [// switch
+				if #mapping.calc[#calcName] != _|_ {#mapping.calc[#calcName]},
+				{#defaultCalc},
+		][0]
+
+		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+		if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
+			format: {
+				unit: #mapping.unit[#unitPath]
+			}
+		}
+		#decimal: *(#panel.fieldConfig.defaults.decimal) | null
+		if #decimal != null {
+			format: {
+				decimalPlaces: #decimal
+			}
+		}
+	}
+}

--- a/BarChart/cue.mod/module.cue
+++ b/BarChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/barchart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/BarChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/GaugeChart/backend/gauge.cue
+++ b/GaugeChart/backend/gauge.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+kind: "GaugeChart"
+spec: close({
+	calculation: common.#calculation
+	format?:     common.#format
+	thresholds?: common.#thresholds
+	max?:        number // determines end value of last threshold color segment when unit is not a percent
+})

--- a/GaugeChart/backend/gauge.json
+++ b/GaugeChart/backend/gauge.json
@@ -1,0 +1,20 @@
+{
+  "kind": "GaugeChart",
+  "spec": {
+    "calculation": "last-number",
+    "format": {
+      "unit": "percent",
+      "decimalPlaces": 2
+    },
+    "thresholds": {
+      "steps": [
+        {
+          "value": 85
+        },
+        {
+          "value": 95
+        }
+      ]
+    }
+  }
+}

--- a/GaugeChart/backend/migrate.cue
+++ b/GaugeChart/backend/migrate.cue
@@ -1,0 +1,39 @@
+if #panel.type != _|_ if #panel.type == "gauge" {
+	kind: "GaugeChart"
+	spec: {
+		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's GaugeChart doesn't support individual calcs
+		calculation: [// switch
+			if #mapping.calc[#calcName] != _|_ {#mapping.calc[#calcName]},
+			#defaultCalc,
+		][0]
+
+		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+		if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
+			format: {
+				unit: #mapping.unit[#unitPath]
+			}
+		}
+		#decimal: *(#panel.fieldConfig.defaults.decimal) | null
+		if #decimal != null {
+			format: {
+				decimalPlaces: #decimal
+			}
+		}
+
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.thresholds.steps != _|_ {
+			thresholds: {
+				// defaultColor: TODO how to fill this one?
+				steps: [for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ {
+					value: [// switch
+						if step.value == null {0},
+						step.value,
+					][0]
+					color: step.color
+				}]
+			}
+		}
+		if #panel.fieldConfig.defaults.max != _|_ {
+			max: #panel.fieldConfig.defaults.max
+		}
+	}
+},

--- a/GaugeChart/cue.mod/module.cue
+++ b/GaugeChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/gaugechart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/GaugeChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/MarkdownChart/backend/markdown.cue
+++ b/MarkdownChart/backend/markdown.cue
@@ -1,0 +1,19 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+kind: "MarkdownChart"
+spec: close({
+	text: string
+})

--- a/MarkdownChart/backend/markdown.json
+++ b/MarkdownChart/backend/markdown.json
@@ -1,0 +1,6 @@
+{
+  "kind": "MarkdownChart",
+  "spec": {
+    "text": "## Some charts!\nOn this page, you'll find charts.\n\nGo to [Google](https://www.google.com)"
+  }
+}

--- a/MarkdownChart/backend/migrate.cue
+++ b/MarkdownChart/backend/migrate.cue
@@ -1,0 +1,15 @@
+// NB: Convert text panels with mode=html as markdown panels as best effort while we dont provide a proper panel type for this
+if #panel.type != _|_ if #panel.type == "text" {
+	if #panel.mode != _|_ {
+		kind: "MarkdownChart"
+		spec: {
+			text: #panel.content
+		}
+	}
+	if #panel.options != _|_ {
+		kind: "MarkdownChart"
+		spec: {
+			text: #panel.options.content
+		}
+	}
+},

--- a/MarkdownChart/cue.mod/module.cue
+++ b/MarkdownChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/markdownchart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/MarkdownChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/PieChart/backend/pie.cue
+++ b/PieChart/backend/pie.cue
@@ -1,0 +1,60 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#legendValue: common.#calculation
+
+#legend: {
+	position: "bottom" | "right"
+	mode?:    "list" | "table"
+	size?:    "small" | "medium"
+	values?: [...#legendValue]
+}
+
+#palette: {
+	mode: "auto" | "categorical"
+}
+
+#visual: {
+	display?:      "line" | "bar"
+	lineWidth?:    number & >=0.25 & <=3
+	areaOpacity?:  number & >=0 & <=1
+	showPoints?:   "auto" | "always"
+	palette?:      #palette
+	pointRadius?:  number & >=0 & <=6
+	stack?:        "all" | "percent" // TODO: percent option is disabled until support is added
+	connectNulls?: bool
+}
+
+kind: "PieChart"
+spec: close({
+	legend?:        #legend
+	querySettings?: #querySettings
+	calculation:    common.#calculation
+	format?:        common.#format
+	sort?:          "asc" | "desc"
+	mode?:          "value" | "percentage"
+	visual?:        #visual
+	radius:         number
+})
+
+#querySettings: [...{
+	queryIndex: int & >=0
+	colorMode:  "fixed" | "fixed-single"       // NB: "palette" could be added later
+	colorValue: =~"^#(?:[0-9a-fA-F]{3}){1,2}$" // hexadecimal color code
+}]

--- a/PieChart/backend/pie.json
+++ b/PieChart/backend/pie.json
@@ -1,0 +1,21 @@
+{
+  "kind": "PieChart",
+  "spec": {
+    "legend": {
+      "position": "bottom"
+    },
+    "visual": {
+      "display": "line",
+      "lineWidth": 2,
+      "pointRadius": 3
+    },
+    "calculation": "last-number",
+    "format": {
+      "unit": "percent",
+      "decimalPlaces": 2
+    },
+    "sort": "desc",
+    "mode": "value",
+    "radius": 50
+  }
+}

--- a/PieChart/cue.mod/module.cue
+++ b/PieChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/piechart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/PieChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/ScatterChart/backend/scatter.cue
+++ b/ScatterChart/backend/scatter.cue
@@ -1,0 +1,19 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+kind: "ScatterChart"
+spec: close({
+	sizeRange?: [number, number]
+})

--- a/ScatterChart/backend/scatter.json
+++ b/ScatterChart/backend/scatter.json
@@ -1,0 +1,4 @@
+{
+  "kind": "ScatterChart",
+  "spec": {}
+}

--- a/ScatterChart/cue.mod/module.cue
+++ b/ScatterChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/scatterchart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/ScatterChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/StatChart/backend/migrate.cue
+++ b/StatChart/backend/migrate.cue
@@ -1,0 +1,39 @@
+if #panel.type != _|_ if #panel.type == "stat" {
+	kind: "StatChart"
+	spec: {
+		#calcName: *"\(#panel.options.reduceOptions.calcs[0])" | null // only consider [0] here as Perses's StatChart doesn't support individual calcs
+		calculation: [// switch
+			if #mapping.calc[#calcName] != _|_ {#mapping.calc[#calcName]},
+			#defaultCalc,
+		][0]
+
+		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+		if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
+			format: {
+				unit: #mapping.unit[#unitPath]
+			}
+		}
+		#decimal: *(#panel.fieldConfig.defaults.decimal) | null
+		if #decimal != null {
+			format: {
+				decimalPlaces: #decimal
+			}
+		}
+
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.thresholds.steps != _|_
+
+		// nothing to map to the `sparkline` field yet
+		{
+			thresholds: {
+				// defaultColor: TODO how to fill this one?
+				steps: [for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ {
+					value: [// switch
+						if step.value == null {0},
+						{step.value},
+					][0]
+					color: step.color // TODO how to manage the overrides part? 
+				}]
+			}
+		}
+	}
+},

--- a/StatChart/backend/stat.cue
+++ b/StatChart/backend/stat.cue
@@ -1,0 +1,32 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+kind: "StatChart"
+spec: close({
+	calculation:    common.#calculation
+	format?:        common.#format
+	thresholds?:    common.#thresholds
+	sparkline?:     #sparkline
+	valueFontSize?: number
+
+	#sparkline: {
+		color?: string
+		width?: number
+	}
+})

--- a/StatChart/backend/stat.json
+++ b/StatChart/backend/stat.json
@@ -1,0 +1,15 @@
+{
+  "kind": "StatChart",
+  "spec": {
+    "calculation": "sum",
+    "format": {
+      "unit": "decimal",
+      "decimalPlaces": 2,
+      "shortValues": true
+    },
+    "sparkline": {
+      "color": "#e65013",
+      "width": 1.5
+    }
+  }
+}

--- a/StatChart/cue.mod/module.cue
+++ b/StatChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/statchart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/StatChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/Table/backend/migrate.cue
+++ b/Table/backend/migrate.cue
@@ -1,0 +1,233 @@
+if #panel.type != _|_ if #panel.type == "table" {
+	kind: "Table"
+	spec: {
+		if #panel.options != _|_ if #panel.options.cellHeight != _|_ {
+			density: [
+				if #panel.options.cellHeight == "sm" {"compact"},
+				if #panel.options.cellHeight == "lg" {"comfortable"},
+				"standard",
+			][0]
+		}
+
+		// /!\ Disabling the improved migration logic from #2273 for columnSettings for now, because it triggers a bug with the new CUE evaluator.
+		// Would need the resolution of this issue to consider bringing it back: https://github.com/cue-lang/cue/issues/3178#issuecomment-2399694260
+		// NB: the commit that appended this comment should be revert since it removed some unit tests.
+		//
+		// intermediary object to gather all the settings/overrides we can find, before taking decisions about which ones to assign to columnSettings
+		// Because CUE doesn't allow to override values, we have to do some tricky stuff like creating unique fields for each "candidate" to avoid conflicts.
+		// _settingsGatherer: {}
+		// _nameBuilder: {
+		// 	#var: string
+		// 	output: [
+		// 		// Rename anonymous fields that Perses names differently than Grafana
+		// 		if #var == "Time" { "timestamp" },
+		// 		if #var == "Value" { "value" },
+		// 		#var
+		// 	][0]
+		// }
+		//if #panel.transformations != _|_ for transformation in #panel.transformations if transformation.id == "organize" {
+		//	if transformation.options.excludeByName != _|_ {
+		//		for excludedColumn, value in transformation.options.excludeByName if value {
+		//			let name = {_nameBuilder & {#var: excludedColumn}}.output
+		//			_settingsGatherer: "\(name)": hide: true
+		//		}}
+		//	if transformation.options.renameByName != _|_ {
+		//		for technicalName, displayName in transformation.options.renameByName {
+		//			let name = {_nameBuilder & {#var: technicalName}}.output
+		//			_settingsGatherer: "\(name)": headers: "\(displayName)": true
+		//		}
+		//	}
+		//}
+		// if #panel.fieldConfig.overrides != _|_ {
+		// 	for override in #panel.fieldConfig.overrides if override.matcher.id == "byName" && override.matcher.options != _|_ {
+		// 		for property in override.properties {
+		// 			let name = {_nameBuilder & {#var: override.matcher.options}}.output
+		// 			if property.id == "displayName" {
+		// 				// Grafana's field overrides can be defined on fields already renamed via the Organize transformation,
+		// 				// hence why we go through the map here to try gathering the renames in the same "place".
+		// 				// NB: this is best effort. E.g if there are several organize transformations chained this wont work, but a settings
+		// 				// object will still get created, thus it could still be arranged manually by the user after the migration.
+		// 				for k, v in _settingsGatherer {
+		// 					if v.headers[name] != _|_ {
+		// 						_settingsGatherer: "\(k)": headers: "\(property.value)": true
+		// 					}
+		// 				}
+		// 				_settingsGatherer: "\(name)": headers: "\(property.value)": true
+		// 			}
+		// 			if property.id == "custom.width" {
+		// 				// same as above
+		// 				for k, v in _settingsGatherer {
+		// 					if v.headers[name] != _|_ {
+		// 						_settingsGatherer: "\(k)": widths: "\(property.value)": true
+		// 					}
+		// 				}
+		// 				_settingsGatherer: "\(name)": widths: "\(property.value)": true
+		// 			}
+		// 		}
+		// 	}
+		// }
+
+		// columnSettings: [for settingsID, settings in _settingsGatherer {
+		// 	name: settingsID
+		// 	if settings.headers != _|_ if len(settings.headers) > 0 {
+		// 		let headers = [for settingKey, _ in settings.headers { settingKey }]
+		// 		// Why do we take the last element here: it's mostly based on grafana's behavior
+		// 		// - field overrides take precedence over the organize transformation (organize transformation was processed first above)
+		// 		// - if there are multiple overrides for the same field, the last one takes precedence
+		// 		header: headers[len(headers) - 1]
+		// 	}
+		// 	if settings.hide != _|_ {
+		// 		hide: settings.hide
+		// 	}
+		// 	if settings.widths != _|_ if len(settings.widths) > 0 {
+		// 		let widths = [for settingKey, _ in settings.widths { settingKey }]
+		// 		width: strconv.Atoi(widths[len(widths) - 1])
+		// 	}
+		// }]
+
+		// Bringing back the old logic from before #2273 + some adjustments due to using cue v0.11.0 + corner case uncovered with unit test added since:
+
+		_excludedColumns: [if #panel.transformations != _|_ for transformation in #panel.transformations if transformation.id == "organize" for excludedColumn, value in transformation.options.excludeByName if value {
+			name: excludedColumn
+			hide: true
+		}]
+
+		// Build intermediary maps to be able to merge settings coming from different places
+		// We use the future 'header' information as a key for both maps here, because this is the common denominator between the two sources
+		// Indeed in grafana the fieldconfig's overrides are matched against the final column name (thus potentially renamed))
+		_renamedMap: {if #panel.transformations != _|_ for transformation in #panel.transformations if transformation.id == "organize" for technicalName, prettyName in transformation.options.renameByName if _renamedMap[prettyName] == _|_ {
+			"\(prettyName)": technicalName
+		}}
+		_customWidthMap: {if #panel.fieldConfig.overrides != _|_ for override in #panel.fieldConfig.overrides if override.matcher.id == "byName" && override.matcher.options != _|_ for property in override.properties if property.id == "custom.width" if _customWidthMap[override.matcher.options] == _|_ {
+			"\(override.matcher.options)": property.value
+		}}
+
+		_prettifiedColumns: list.Concat([[for rKey, rVal in _renamedMap {
+			name:   rVal
+			header: rKey
+			if _customWidthMap[rKey] != _|_ {
+				width: _customWidthMap[rKey]
+			}
+		}], [for cwKey, cwVal in _customWidthMap if _renamedMap[cwKey] == _|_ {
+			name:  cwKey
+			width: cwVal
+		}]])
+
+		columnSettings: list.Concat([_excludedColumns, _prettifiedColumns])
+
+		// Using flatten to avoid having an array of arrays with "value" mappings
+		// (https://cuelang.org/docs/howto/use-list-flattenn-to-flatten-lists/)
+		let x = list.FlattenN([
+			if #panel.fieldConfig != _|_ && #panel.fieldConfig.defaults != _|_ && #panel.fieldConfig.defaults.mappings != _|_ for mapping in #panel.fieldConfig.defaults.mappings {
+				if mapping.type == "value" {
+					[for key, option in mapping.options {
+						condition: {
+							kind: "Value"
+							spec: {
+								value: key
+							}
+						}
+						if option.text != _|_ {
+							text: option.text
+						}
+						if option.color != _|_ {
+							backgroundColor: [// switch
+								if #mapping.color[option.color] != _|_ {#mapping.color[option.color]},
+								option.color,
+							][0]
+						}
+					}]
+				}
+
+				if mapping.type == "range" || mapping.type == "regex" || mapping.type == "special" {
+					condition: [//switch
+						if mapping.type == "range" {
+							kind: "Range",
+							spec: {
+								if mapping.options.from != _|_ {
+									min: mapping.options.from
+								}
+								if mapping.options.to != _|_ {
+									max: mapping.options.to
+								}
+							}
+						},
+						if mapping.type == "regex" {
+							kind: "Regex",
+							spec: {
+								expr: mapping.options.pattern
+							}
+						},
+						if mapping.type == "special" {
+							kind: "Misc",
+							spec: {
+								value: [//switch
+									if mapping.options.match == "nan" {"NaN"},
+									if mapping.options.match == "null+nan" {"null"},
+									mapping.options.match,
+								][0]
+							}
+						},
+					][0]
+
+					if mapping.options.result.text != _|_ {text: mapping.options.result.text}
+					if mapping.options.result.color != _|_ {
+						backgroundColor: [// switch
+							if #mapping.color[mapping.options.result.color] != _|_ {#mapping.color[mapping.options.result.color]},
+							mapping.options.result.color,
+						][0]
+					}
+				}
+			},
+		], 1)
+
+		if len(x) > 0 {cellSettings: x}
+
+		if #panel.transformations != _|_ {
+			#transforms: [
+				for transformation in #panel.transformations if transformation.id == "merge" || transformation.id == "joinByField" {
+					if transformation.id == "merge" {
+						kind: "MergeSeries"
+						spec: {
+							if transformation.disabled != _|_ {
+								disabled: transformation.disabled
+							}
+						}
+					}
+					if transformation.id == "joinByField" {
+						kind: "JoinByColumnValue"
+						spec: {
+							[// switch
+								if transformation.options.byField != _|_ {columns: [transformation.options.byField]},
+								{columns: []},
+							][0]
+							if transformation.disabled != _|_ {
+								disabled: transformation.disabled
+							}
+						}
+					}
+				},
+			]
+			if len(#transforms) > 0 {transforms: #transforms}
+		}
+	}
+},
+if #panel.type != _|_ if #panel.type == "table-old" {
+	kind: "Table"
+	spec: {
+		if #panel.styles != _|_ {
+			columnSettings: [for style in #panel.styles {
+				name: style.pattern
+				if style.type == "hidden" {
+					hide: true
+				}
+				if style.alias != _|_ {
+					header: style.alias
+				}
+				if style.align != _|_ if style.align != "auto" {
+					align: style.align
+				}
+			}]
+		}
+	}
+},

--- a/Table/backend/table.cue
+++ b/Table/backend/table.cue
@@ -1,0 +1,78 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"strings"
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+kind: "Table"
+spec: close({
+	density?: "compact" | "standard" | "comfortable"
+	columnSettings?: [...#columnSettings]
+	cellSettings?: [...#cellSettings]
+	transforms?: [...common.#transform]
+})
+
+#columnSettings: {
+	name:               strings.MinRunes(1)
+	header?:            string
+	headerDescription?: string
+	cellDescription?:   string
+	align?:             "left" | "center" | "right"
+	enableSorting?:     bool
+	width?:             number | "auto"
+	hide?:              bool
+}
+
+#valueCondition: {
+	kind: "Value"
+	spec: {
+		value: strings.MinRunes(1)
+	}
+}
+
+#rangeCondition: {
+	kind: "Range"
+	spec: {
+		min?: number
+		max?: number
+	}
+}
+
+#regexCondition: {
+	kind: "Regex"
+	spec: {
+		expr: strings.MinRunes(1)
+	}
+}
+
+#miscCondition: {
+	kind: "Misc"
+	spec: {
+		value: "empty" | "null" | "NaN" | "true" | "false"
+	}
+}
+
+#condition: {
+	#valueCondition | #rangeCondition | #regexCondition | #miscCondition
+}
+
+#cellSettings: {
+	condition:        #condition
+	text?:            string
+	textColor?:       =~"^#(?:[0-9a-fA-F]{3}){1,2}$"
+	backgroundColor?: =~"^#(?:[0-9a-fA-F]{3}){1,2}$"
+}

--- a/Table/backend/table.json
+++ b/Table/backend/table.json
@@ -1,0 +1,18 @@
+{
+  "kind": "Table",
+  "spec": {
+    "density": "compact",
+    "columnSettings" : [
+      {
+        "name": "value",
+        "header": "Value",
+        "headerDescription": "The value of the time serie",
+        "cellDescription": "Useless and not mandatory",
+        "align": "left",
+        "enableSorting": true,
+        "width": "auto",
+        "hide": false
+      }
+    ]
+  }
+}

--- a/Table/cue.mod/module.cue
+++ b/Table/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/table@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/Table/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/TimeSeriesChart/backend/migrate.cue
+++ b/TimeSeriesChart/backend/migrate.cue
@@ -1,0 +1,106 @@
+if #panel.type != _|_ if #panel.type == "timeseries" || #panel.type == "graph" {
+	kind: "TimeSeriesChart"
+	spec: {
+		// legend
+		// NB: no support of former "show" attribute from Grafana, people should migrate to latest Grafana datamodel before migrating to Perses
+		#showLegend: *#panel.options.legend.showLegend | true
+		if #panel.options.legend != _|_ if #showLegend {
+			legend: {
+				if #panel.type == "timeseries" {
+					position: [
+						if #panel.options.legend.placement != _|_ if #panel.options.legend.placement == "right" {"right"},
+						"bottom",
+					][0]
+					mode: [
+						if #panel.options.legend.displayMode == "table" {"table"},
+						"list",
+					][0]
+					values: [for calc in #panel.options.legend.calcs
+						if (#mapping.calc[calc] != _|_) {#mapping.calc[calc]},
+					]
+				}
+				if #panel.type == "graph" {
+					position: [// switch
+						if #panel.legend.rightSide != _|_ if #panel.legend.rightSide {"right"},
+						"bottom",
+					][0]
+					mode: [
+						if #panel.legend.alignAsTable != _|_ if #panel.legend.alignAsTable {"table"},
+						"list",
+					][0]
+					values: [for oldCalc, newCalc in #mapping.calc
+						// Check if the mapping field is set on the legend and 
+						// is true.
+						if #panel.legend[oldCalc] != _|_ if #panel.legend[oldCalc] == true {newCalc},
+					]
+				}
+			}
+		}
+
+		// yAxis
+		#unitPath: *"\(#panel.fieldConfig.defaults.unit)" | null
+		if #unitPath != null if #mapping.unit[#unitPath] != _|_ {
+			yAxis: {
+				format: {
+					unit: #mapping.unit[#unitPath]
+				}
+			}
+		}
+		#min: *#panel.fieldConfig.defaults.min | null
+		if #min != null {
+			yAxis: {
+				min: #min
+			}
+		}
+		#max: *#panel.fieldConfig.defaults.max | null
+		if #max != null {
+			yAxis: {
+				max: #max
+			}
+		}
+
+		// thresholds
+		// -> migrate thresholds only if they are visible
+		if #panel.fieldConfig.defaults.thresholds != _|_ if #panel.fieldConfig.defaults.thresholds.steps != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle != _|_ if #panel.fieldConfig.defaults.custom.thresholdsStyle.mode != "off" {
+			thresholds: {
+				// defaultColor: TODO how to fill this one?
+				steps: [for _, step in #panel.fieldConfig.defaults.thresholds.steps if step.value != _|_ {
+					value: [// switch
+						if step.value == null {0},
+						step.value,
+					][0]
+					color: step.color // TODO how to manage the overrides part?
+				}]
+			}
+		}
+
+		// visual
+		visual: {
+			if #panel.fieldConfig.defaults.custom.lineWidth != _|_ {
+				lineWidth: [// switch
+					if #panel.fieldConfig.defaults.custom.lineWidth > 3 {3},       // line width can't go beyond 3 in Perses
+					if #panel.fieldConfig.defaults.custom.lineWidth < 0.25 {0.25}, // line width can't go below 0.25 in Perses
+					#panel.fieldConfig.defaults.custom.lineWidth,
+				][0]
+			}
+			if #panel.fieldConfig.defaults.custom.fillOpacity != _|_ {
+				areaOpacity: #panel.fieldConfig.defaults.custom.fillOpacity / 100 // 
+			}
+
+			// NB: pointRadius skipped because the optimal size is automatically computed by Perses
+			if #panel.fieldConfig.defaults.custom.spanNulls != _|_ if (#panel.fieldConfig.defaults.custom.spanNulls & bool) != _|_ {
+				connectNulls: #panel.fieldConfig.defaults.custom.spanNulls // ignore in case of "threshold" mode because we don't support it
+			}
+			if #panel.fieldConfig.defaults.custom.drawStyle != _|_ {
+				display: [// switch
+					if #panel.fieldConfig.defaults.custom.drawStyle == "line" {"line"},
+					if #panel.fieldConfig.defaults.custom.drawStyle == "bars" {"bar"},
+					"line",
+				][0]
+			}
+			if #panel.fieldConfig.defaults.custom.stacking != _|_ if #panel.fieldConfig.defaults.custom.stacking.mode != _|_ if #panel.fieldConfig.defaults.custom.stacking.mode != "none" {
+				stack: "all"
+			}
+		}
+	}
+},

--- a/TimeSeriesChart/backend/time-series.cue
+++ b/TimeSeriesChart/backend/time-series.cue
@@ -1,0 +1,70 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#legendValue: common.#calculation
+
+#legend: {
+	position: "bottom" | "right"
+	mode?:    "list" | "table"
+	size?:    "small" | "medium"
+	values?: [...#legendValue]
+}
+
+#tooltip: {
+	enablePinning?: bool
+}
+
+#palette: {
+	mode: "auto" | "categorical"
+}
+
+#visual: {
+	display?:      "line" | "bar"
+	lineWidth?:    number & >=0.25 & <=3
+	areaOpacity?:  number & >=0 & <=1
+	showPoints?:   "auto" | "always"
+	palette?:      #palette
+	pointRadius?:  number & >=0 & <=6
+	stack?:        "all" | "percent" // TODO: percent option is disabled until support is added
+	connectNulls?: bool
+}
+
+#yAxis: {
+	show?:   bool
+	label?:  string
+	format?: common.#format
+	min?:    number
+	max?:    number
+}
+
+kind: "TimeSeriesChart"
+spec: close({
+	legend?:        #legend
+	tooltip?:       #tooltip
+	yAxis?:         #yAxis
+	thresholds?:    common.#thresholds
+	visual?:        #visual
+	querySettings?: #querySettings
+})
+
+#querySettings: [...{
+	queryIndex: int & >=0
+	colorMode:  "fixed" | "fixed-single"       // NB: "palette" could be added later
+	colorValue: =~"^#(?:[0-9a-fA-F]{3}){1,2}$" // hexadecimal color code
+}]

--- a/TimeSeriesChart/backend/time-series.json
+++ b/TimeSeriesChart/backend/time-series.json
@@ -1,0 +1,35 @@
+{
+  "kind": "TimeSeriesChart",
+  "spec": {
+    "yAxis": {
+      "show": true,
+      "label": "CPU",
+      "min": 0.2,
+      "max": 0.4,
+      "format": {
+        "unit": "decimal",
+        "decimalPlaces": 2
+      }
+    },
+    "legend": {
+      "position": "bottom"
+    },
+    "thresholds": {
+      "steps": [
+        {
+          "value": 0.6,
+          "name": "Alert: Warning condition example"
+        },
+        {
+          "value": 0.8,
+          "name": "Alert: Critical condition example"
+        }
+      ]
+    },
+    "visual": {
+      "display": "line",
+      "lineWidth": 2,
+      "pointRadius": 3
+    }
+  }
+}

--- a/TimeSeriesChart/cue.mod/module.cue
+++ b/TimeSeriesChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/timeserieschart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/TimeSeriesChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/TimeSeriesTable/backend/time-series-table.cue
+++ b/TimeSeriesTable/backend/time-series-table.cue
@@ -1,0 +1,17 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+kind: "TimeSeriesTable"
+spec: close({})

--- a/TimeSeriesTable/backend/time-series-table.json
+++ b/TimeSeriesTable/backend/time-series-table.json
@@ -1,0 +1,4 @@
+{
+  "kind": "TimeSeriesTable",
+  "spec": {}
+}

--- a/TimeSeriesTable/cue.mod/module.cue
+++ b/TimeSeriesTable/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/timeseriestable@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/TimeSeriesTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/TraceTable/backend/trace-table.cue
+++ b/TraceTable/backend/trace-table.cue
@@ -1,0 +1,27 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+#palette: {
+	mode: "auto" | "categorical"
+}
+
+#visual: {
+	palette?: #palette
+}
+
+kind: "TraceTable"
+spec: close({
+	visual?: #visual
+})

--- a/TraceTable/backend/trace-table.json
+++ b/TraceTable/backend/trace-table.json
@@ -1,0 +1,4 @@
+{
+  "kind": "TraceTable",
+  "spec": {}
+}

--- a/TraceTable/cue.mod/module.cue
+++ b/TraceTable/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/tracetable@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/TraceTable/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/TracingGanttChart/backend/tracing-gantt-chart.cue
+++ b/TracingGanttChart/backend/tracing-gantt-chart.cue
@@ -1,0 +1,27 @@
+// Copyright 2024 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+#palette: {
+	mode: "auto" | "categorical"
+}
+
+#visual: {
+	palette?: #palette
+}
+
+kind: "TracingGanttChart"
+spec: close({
+	visual?: #visual
+})

--- a/TracingGanttChart/backend/tracing-gantt-chart.json
+++ b/TracingGanttChart/backend/tracing-gantt-chart.json
@@ -1,0 +1,4 @@
+{
+  "kind": "TracingGanttChart",
+  "spec": {}
+}

--- a/TracingGanttChart/cue.mod/module.cue
+++ b/TracingGanttChart/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/perses/plugins/tracingganttchart@v0"
+language: {
+	version: "v0.10.0"
+}

--- a/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
+++ b/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/calculation.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#calculation: "first" | *"last" | "first-number" | "last-number" | "mean" | "sum" | "min" | "max"

--- a/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
+++ b/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/format.cue
@@ -1,0 +1,44 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#format: #timeFormat | #percentFormat | #decimalFormat | #bytesFormat | #throughputFormat
+
+#timeFormat: {
+	unit:           "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years"
+	decimalPlaces?: number
+}
+
+#percentFormat: {
+	unit:           "percent" | "percent-decimal"
+	decimalPlaces?: number
+}
+
+#decimalFormat: {
+	unit:           "decimal"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#bytesFormat: {
+	unit:           "bytes"
+	decimalPlaces?: number
+	shortValues?:   bool
+}
+
+#throughputFormat: {
+	unit:           "bits/sec" | "bytes/sec" | "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec"
+	decimalPlaces?: number
+	shortValues?:   bool
+}

--- a/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
+++ b/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/proxy/http.cue
@@ -1,0 +1,40 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"github.com/perses/perses/cue/schemas/common"
+)
+
+#HTTPAllowedEndpoint: {
+	endpointPattern: string
+	method:          "POST" | "PUT" | "PATCH" | "GET" | "DELETE"
+}
+
+#HTTPProxy: {
+	kind: "HTTPProxy"
+	spec: {
+		// url is the url of the datasource. It is not the url of the proxy.
+		// The Perses server is the proxy, so it needs to know where to redirect the request.
+		url: common.#url
+		// allowedEndpoints is a list of tuples of http methods and http endpoints that will be accessible.
+		// Leave it empty if you don't want to restrict the access to the datasource.
+		allowedEndpoints?: [...#HTTPAllowedEndpoint]
+		// headers can be used to provide additional headers that need to be forwarded when requesting the datasource
+		headers?: {[string]: string}
+		// secret is the name of the secret that should be used for the proxy or discovery configuration
+		// It will contain any sensitive information such as password, token, certificate.
+		secret?: string
+	}
+}

--- a/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
+++ b/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/threshold.cue
@@ -1,0 +1,26 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#stepOption: {
+	value:  number
+	color?: string
+	name?:  string
+}
+
+#thresholds: {
+	mode?:         "percent" | "absolute"
+	defaultColor?: string
+	steps?: [...#stepOption]
+}

--- a/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
+++ b/TracingGanttChart/cue.mod/pkg/github.com/perses/perses/cue/schemas/common/url.cue
@@ -1,0 +1,16 @@
+// Copyright 2023 The Perses Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+#url: =~"^https?:\/\/[^\\s\/$.?#].[^\\s]*$"

--- a/docs/panels.md
+++ b/docs/panels.md
@@ -1,0 +1,258 @@
+# Panel plugins
+
+This documentation provides an exhaustive list of the panel plugins supported by Perses.
+
+## BarChart
+
+```yaml
+kind: "BarChart"
+spec:
+  calculation: <Calculation specification>
+  format: <Format specification> # Optional
+  sort: <enum = "asc" | "desc"> # Optional
+  mode: <enum = "value" | "percentage"> # Optional
+```
+
+## GaugeChart
+
+```yaml
+kind: "GaugeChart"
+spec:
+  calculation: <Calculation specification>
+  format: <Format specification> # Optional
+  thresholds: <Thresholds specification> # Optional
+  max: <int> # Optional
+```
+
+## Markdown
+
+```yaml
+kind: "Markdown"
+spec:
+  text: <string>
+```
+
+## PieChart
+
+```yaml
+kind: "PieChart"
+# TODO document the spec of PieChart
+```
+
+## StatChart
+
+```yaml
+kind: "StatChart"
+spec:
+  calculation: <Calculation specification>
+  format: <Format specification> # Optional
+  thresholds: <Thresholds specification> # Optional
+  sparkline: <Sparkline specification> # Optional
+  valueFontSize: <int> # Optional
+```
+
+### Sparkline specification
+
+```yaml
+color: <string> # Optional
+width: <int> # Optional
+```
+
+## ScatterChart
+
+```yaml
+kind: "ScatterChart"
+spec: # TODO document the spec of ScatterChart
+```
+
+## Table
+
+```yaml
+kind: "Table"
+spec:
+  density: <enum = "compact" | "standard" | "comfortable"> # Optional
+  columnSettings: <Column Settings specification> # Optional
+```
+
+### Column Settings specification
+
+```yaml
+name:  <string>
+header:  <string> # Optional
+headerDescription:  <string> # Optional
+cellDescription: <string> # Optional
+align: <enum = "left" | "center" | "right"> # Optional
+enableSorting: <boolean> # Optional
+width: <number | "auto"> # Optional
+hide: <boolean> # Optional
+```
+
+## TimeSeriesChart
+
+```yaml
+kind: "TimeSeriesChart"
+spec:
+  legend: <Legend specification> # Optional
+  tooltip: <Tooltip specification> # Optional
+  yAxis: <YAxis specification> # Optional
+  thresholds: <Thresholds specification> # Optional
+  visual: <Visual specification> # Optional
+  querySettings:
+  - <Query Settings specification> # Optional
+```
+
+### Legend specification
+
+```yaml
+position: <enum = "bottom" | "right">
+mode: <enum = "list" | "table"> # Optional
+size: <enum = "small" | "medium"> # Optional
+values:
+  - <calculation> # Optional
+```
+
+### Tooltip specification
+
+```yaml
+enablePinning: <boolean | default = false> # Optional
+```
+
+### YAxis specification
+
+```yaml
+show: <boolean> # Optional
+label: <string> # Optional
+format: <format_spec> # Optional
+min: <int> # Optional
+max: <int> # Optional
+```
+
+### Visual specification
+
+```yaml
+display: <enum = "line" | "bar"> # Optional
+# Must be between 0.25 and 3
+lineWidth: <int> # Optional
+# Must be between 0 and 1
+areaOpacity: <int> # Optional
+showPoints: <enum = "auto" | "always"> # Optional
+palette: <Palette specification> # Optional
+# Must be between 0 and 6
+pointRadius: <number> # Optional
+stack: <enum = "all" | "percent"> # Optional
+connectNulls: boolean | default = false # Optional
+```
+
+#### Palette specification
+
+```yaml
+mode: <enum = "auto" | "categorical">
+```
+
+### Query Settings specification
+
+```yaml
+# queryIndex is an unsigned integer that should match an existing index in the panel's `queries` array
+queryIndex: <number>
+# colorMode represents the coloring strategy to use
+# - "fixed":        for any serie returned by the query, apply the colorValue defined
+# - "fixed-single": if only one serie returned by the query, apply the colorValue defined, otherwise do nothing
+colorMode: <enum = "fixed" | "fixed-single">
+# colorValue is an hexadecimal color code
+colorValue: <string>
+```
+
+## TimeSeriesTable
+
+```yaml
+kind: "TimeSeriesTable"
+# TODO document the spec of TimeSeriesTable
+```
+
+## TraceTable
+
+```yaml
+kind: "TraceTable"
+# TODO document the spec of TraceTable
+```
+
+## TracingGanttChart
+
+```yaml
+kind: "TracingGanttChart"
+# TODO document the spec of TracingGanttChart
+```
+
+## Common definitions
+
+### Calculation specification
+
+It's an enum. Possible values are:
+
+- `first`
+- `last`
+- `first-number`
+- `last-number`
+- `mean`
+- `sum`
+- `min`
+- `max`
+
+### Format specification
+
+The format spec is one of the following:
+
+#### Time format
+
+```yaml
+unit: <enum = "milliseconds" | "seconds" | "minutes" | "hours" | "days" | "weeks" | "months" | "years">
+decimalPlaces: <int> # Optional
+```
+
+#### Percent format
+
+```yaml
+unit: <enum =  "percent" | "percent-decimal">
+decimalPlaces: <int> # Optional
+```
+
+#### Decimal format
+
+```yaml
+unit: "decimal"
+decimalPlaces: <int> # Optional
+shortValues: <boolean> | default = false # Optional
+```
+
+#### Bytes format
+
+```yaml
+unit: "bytes"
+decimalPlaces: <int> # Optional
+shortValues: <boolean> | default = false # Optional
+```
+
+#### Throughput format
+
+```yaml
+unit: < enum = "counts/sec" | "events/sec" | "messages/sec" | "ops/sec" | "packets/sec" | "reads/sec" | "records/sec" | "requests/sec" | "rows/sec" | "writes/sec">
+decimalPlaces: <int> # Optional
+shortValues: <boolean> | default = false # Optional
+```
+
+### Thresholds specification
+
+```yaml
+mode: <enum = "percent" | "absolute"> # Optional
+defaultColor: string # Optional
+steps:
+  - <Step specification> # Optional
+```
+
+#### Step specification
+
+```yaml
+value: <int>
+color: <string> # Optional
+name: <string> # Optional
+```


### PR DESCRIPTION
- Add CUE files for all panel plugins. Copied from [perses/perses](https://github.com/perses/perses) at revision `cdd8360987e5051ad056ffa506386fa0dbe4d4fd`
- Make each plugin a standalone CUE module
   - Vendor/copy the common package dependency for each plugin
- Copy also the plugins-specific doc

This is a first step of the plan I described here https://github.com/perses/perses/discussions/2085#discussioncomment-11078190